### PR TITLE
Normalize L as 1

### DIFF
--- a/crockford.go
+++ b/crockford.go
@@ -71,7 +71,7 @@ func normUpper(c byte) byte {
 	switch c {
 	case '0', 'O', 'o':
 		return '0'
-	case '1', 'I', 'i':
+	case '1', 'I', 'i', 'L', 'l':
 		return '1'
 	case '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'X', 'Y', 'Z', '*', '~', '$', '=', 'U':
 		return c
@@ -82,14 +82,14 @@ func normUpper(c byte) byte {
 }
 
 // Normalized returns a normalized version of Crockford encoded bytes of src
-// onto dst and returns the resulting slice. It replaces I with 1, o with 0,
+// onto dst and returns the resulting slice. It replaces I and L with 1, o with 0,
 // and removes invalid characters such as hyphens. The resulting slice is uppercase.
 func Normalized(s string) string {
 	return string(AppendNormalized(nil, []byte(s)))
 }
 
 // AppendNormalized appends a normalized version of Crockford encoded bytes of src
-// onto dst and returns the resulting slice. It replaces I with 1, o with 0,
+// onto dst and returns the resulting slice. It replaces I and L with 1, o with 0,
 // and removes invalid characters such as hyphens. The resulting slice is uppercase.
 func AppendNormalized(dst, src []byte) []byte {
 	dst = grow(dst, len(src))

--- a/crockford_test.go
+++ b/crockford_test.go
@@ -239,3 +239,21 @@ func chunk(s string, size int) []string {
 	}
 	return append(res, s[(n-1)*size:])
 }
+
+func TestNormalized(t *testing.T) {
+	for _, tc := range []struct {
+		in, out string
+	}{
+		{"", ""},
+		{"a", "A"},
+		{"1IiLl", "11111"},
+		{"0Oo", "000"},
+		{"-", ""},
+		{"AB-C", "ABC"},
+		{"AB-C--DEF", "ABCDEF"},
+		{"0123456789abcdefghjkmnpqrstvwxyz*~$=u", "0123456789ABCDEFGHJKMNPQRSTVWXYZ*~$=U"},
+	} {
+		got := crockford.Normalized(tc.in)
+		be.Equal(t, tc.out, got)
+	}
+}


### PR DESCRIPTION
Thank you for that great library.

As denoted in the table on the right L and l should also be treated as 1.

I also saw that the text is not clear about the character L. I would interpret the table on the right so that L should be replaced with 1. I would appreciate if you would merge this change into your library.

Thank you.